### PR TITLE
Remove unneeded metadata from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "dapps",
-  "version": "0.1.0",
   "private": true,
   "resolutions": {
     "**/optimist/minimist": "^1.2.5",


### PR DESCRIPTION
This PR removes unneeded metadata (i.e. the `name` and `version` for a private package) from the `package.json` file.