### PR TITLE
Add platform check

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -11,7 +11,6 @@ body {
 
 .App {
   font-family: 'Roboto', sans-serif;
-  background-color: #f5f7f8;
   padding-bottom: 0px;
   max-width: 768px;
   margin: auto;

--- a/src/data/all-dapps.js
+++ b/src/data/all-dapps.js
@@ -2,6 +2,11 @@ import { library } from '@fortawesome/fontawesome-svg-core'
 import { faCreditCard,faDice, faCommentAlt, faMoneyBillWave, faNewspaper, faWrench, faExchangeAlt, faStore  } from '@fortawesome/free-solid-svg-icons'
 library.add(faCreditCard, faDice, faCommentAlt, faMoneyBillWave, faNewspaper, faWrench, faExchangeAlt, faStore)
 
+const PLATFORM = 'platform';
+const IOS = 'ios';
+const params = new URLSearchParams(window.location.search);
+const platform = params.get(PLATFORM);
+
 const categories =  [
     {
         name: 'Decentralized finance',
@@ -157,6 +162,7 @@ const categories =  [
     },
     {
         name: 'Art & collectibles',
+        displayIos: false,
         icon: 'store',
         color: '#F29D62',
         dapps: [
@@ -396,5 +402,7 @@ const categories =  [
     }
 ];
 
+// hide any of the above on iOS when displayIos is false
+const filtered = categories.filter(({ displayIos = true }) => !(platform === IOS && !displayIos));
 
-export default categories;
+export default filtered;


### PR DESCRIPTION
This PR hides Art & Collectibles from the homepage when the user is on ios

this relies on https://github.com/MetaMask/dapps/pull/77 which allows to reliably check for the platform OS anywhere on the homepage so that we can change behavior or display different content based on that

**android:**

![image](https://user-images.githubusercontent.com/675259/111541044-5ba60700-8746-11eb-940a-f4d6a32ab135.png)

**ios:**

![image](https://user-images.githubusercontent.com/675259/111541113-6fea0400-8746-11eb-8a95-29b7e332736a.png)

re: MetaMask/mobile-planning#82