### PR TITLE
Analytics: Track events

### DIFF
--- a/src/components/Autocomplete/index.js
+++ b/src/components/Autocomplete/index.js
@@ -1,10 +1,18 @@
 import React, { Component } from 'react';
 import onUrlSubmit from '../../util/browser';
+import{trackEvent, ANALYTICS_EVENT_OPTS} from '../../util/analytics';
 import './index.css';
 
 export default class Autocomplete extends Component {
     state = {
         value: ''
+    }
+
+    trackEventSearchUsed = () => {
+        trackEvent(ANALYTICS_EVENT_OPTS.SEARCH_USED, {
+            option_chosen: 'Search bar on dapp listing',
+            number_of_tabs: undefined,
+        });
     }
 
     handleChange = (event) => {
@@ -18,6 +26,7 @@ export default class Autocomplete extends Component {
 
     handleSubmit = (event) => {
         event.preventDefault();
+        this.trackEventSearchUsed();
         const searchEngine = window.__mmSearchEngine || 'DuckDuckGo';
         const sanitizedInput = onUrlSubmit(this.state.value, searchEngine);
         window.location.href = sanitizedInput;

--- a/src/components/Favorites/index.js
+++ b/src/components/Favorites/index.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import { getHost } from '../../util/browser';
+import{trackEvent, ANALYTICS_EVENT_OPTS} from '../../util/analytics';
 import Dapp from '../Dapp';
 import './index.css';
 
@@ -24,6 +25,10 @@ export default class Favorites extends Component {
     onClose = async (url) => {
         const { favorites } = await window.ethereum.send('metamask_removeFavorite', [url]);
         this.setState({ favorites: favorites.reverse() });
+    }
+
+    trackEventFavoritesOpened() {
+        trackEvent(ANALYTICS_EVENT_OPTS.CLICKS_FAVORITES_TAB);
     }
 
     renderFavorites(){
@@ -58,6 +63,7 @@ export default class Favorites extends Component {
     }
 
     render(){
+        this.trackEventFavoritesOpened()
         if(!this.state.favorites || !this.state.favorites.length) {
            return this.renderEmpty();
         }

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -32,7 +32,7 @@ const isMobile = {
 
 export default class Home extends Component {
     componentDidMount() {
-      trackEvent(ANALYTICS_EVENT_OPTS.IMPRESSION);
+        trackEvent(ANALYTICS_EVENT_OPTS.IMPRESSION);
     }
 
     render() {

--- a/src/util/analytics.js
+++ b/src/util/analytics.js
@@ -13,10 +13,12 @@ export function trackEvent(action, data){
 const generateOpt = (category, action, name) => ({ category, action, name });
 
 const NAMES = {
-    DAPP: 'Dapp',
-    FEATURED_DAPP: 'Featured Dapp',
+	DAPP: 'Dapp',
+	FEATURED_DAPP: 'Featured Dapp',
 	DAPP_CATEGORY: 'Dapp Category',
-    HOMEPAGE_TAB: 'Homepage Tab',
+	HOMEPAGE_TAB: 'Homepage Tab',
+	OPEN_FAVORITE: 'Opened Favorites',
+	SEARCH_USED: 'Search Used',
 };
 
 const ACTIONS = {
@@ -53,6 +55,12 @@ export const ANALYTICS_EVENT_OPTS = {
 		CATEGORIES.BROWSER_HOME,
 		ACTIONS.IMPRESSION,
 	),
+	CLICKS_FAVORITES_TAB: generateOpt(
+		NAMES.OPEN_FAVORITE
+	),
+	SEARCH_USED: generateOpt(
+		NAMES.SEARCH_USED
+	)
 };
 
 export default {trackEvent,ANALYTICS_EVENT_OPTS }


### PR DESCRIPTION
As part of the browser analytics, it is necessary to add two events to home.metamask.io

The events are:

- [x] Open favorites tab.
- [x] Use search bar.