### PR TITLE
[improvement] Refactor autocomplete search to blur after autocomplete is shown

### DIFF
--- a/src/components/Autocomplete/index.css
+++ b/src/components/Autocomplete/index.css
@@ -14,13 +14,9 @@
 }
 
 .autocomplete-input {
-    display: flex;
-    align-items: center;
     width: 100%;
     font-size: 16px;
     outline-width: 0;
     border: 0px;
     -webkit-appearance: none;
-    color: darkgray;
-    padding-left: 8px; 
 }

--- a/src/components/Autocomplete/index.css
+++ b/src/components/Autocomplete/index.css
@@ -14,9 +14,13 @@
 }
 
 .autocomplete-input {
+    display: flex;
+    align-items: center;
     width: 100%;
     font-size: 16px;
     outline-width: 0;
     border: 0px;
     -webkit-appearance: none;
+    color: darkgray;
+    padding-left: 8px; 
 }

--- a/src/components/Autocomplete/index.js
+++ b/src/components/Autocomplete/index.js
@@ -24,6 +24,10 @@ export default class Autocomplete extends Component {
         window.ethereum.send('metamask_showAutocomplete');
     };
 
+    onBlur = (event) => {
+        event.target.blur()
+    }
+
     handleSubmit = (event) => {
         event.preventDefault();
         this.trackEventSearchUsed();
@@ -46,6 +50,7 @@ export default class Autocomplete extends Component {
                     value={this.state.value}
                     onChange={this.handleChange} 
                     onFocus={this.onFocus}
+                    onBlur={this.onBlur}
                 />
             </form>
         );

--- a/src/components/Autocomplete/index.js
+++ b/src/components/Autocomplete/index.js
@@ -20,7 +20,6 @@ export default class Autocomplete extends Component {
     }
 
     onFocus = (event) => {
-        event.preventDefault();
         window.ethereum.send('metamask_showAutocomplete');
     };
 
@@ -38,21 +37,11 @@ export default class Autocomplete extends Component {
 
    render(){
         return (
-            <form 
-                className={'autocomplete'}
-                onSubmit={this.handleSubmit}
-            >
-                <input
-                    autoCapitalize="none"
-                    type={'text'} 
-                    placeholder={'Search or Type URL'} 
-                    className={'autocomplete-input'}
-                    value={this.state.value}
-                    onChange={this.handleChange} 
-                    onFocus={this.onFocus}
-                    onBlur={this.onBlur}
-                />
-            </form>
+            <div className={'autocomplete'} onClick={this.onFocus}>
+                <div className={'autocomplete-input'}>
+                Search or Type URL
+                </div>    
+            </div>
         );
     }
 }

--- a/src/components/Autocomplete/index.js
+++ b/src/components/Autocomplete/index.js
@@ -20,12 +20,11 @@ export default class Autocomplete extends Component {
     }
 
     onFocus = (event) => {
+        event.preventDefault();
         window.ethereum.send('metamask_showAutocomplete');
-    };
-
-    onBlur = (event) => {
+        // needs to be blurred or else it will still be focused when the metamask mobile modal closes triggering an infinite loop
         event.target.blur()
-    }
+    };
 
     handleSubmit = (event) => {
         event.preventDefault();
@@ -37,11 +36,20 @@ export default class Autocomplete extends Component {
 
    render(){
         return (
-            <div className={'autocomplete'} onClick={this.onFocus}>
-                <div className={'autocomplete-input'}>
-                Search or Type URL
-                </div>    
-            </div>
+            <form 
+                className={'autocomplete'}
+                onSubmit={this.handleSubmit}
+            >
+                <input
+                    autoCapitalize="none"
+                    type={'text'} 
+                    placeholder={'Search or Type URL'} 
+                    className={'autocomplete-input'}
+                    value={this.state.value}
+                    onChange={this.handleChange} 
+                    onFocus={this.onFocus}
+                />
+            </form>
         );
     }
 }


### PR DESCRIPTION
## What
- blur the input after we send the event `metamask_showAutocomplete`

## Why?
- this issue was discovered in [this refactor](https://github.com/MetaMask/metamask-mobile/pull/4052) and is needed to ship that change in metamask mobile
- Every-time we fire the event [window.ethereum.send('metamask_showAutocomplete');](https://github.com/MetaMask/dapps/pull/121/files#diff-0d88e47ecb3b87b3e1e80330101345706f8c46937352d1059d2560da4b08b8aeR24) it makes a call to [toggleUrlModal](https://github.com/MetaMask/metamask-mobile/pull/4052/files#diff-5f97a8db92c37dcdf7a575d4e7226b84e0dca1719f9c906fdcf59faae0cbb092R491) in the MetaMask mobile browser. 
    - as you can guess this triggers the new modal
- When the modal closes the input is still focused and since we toggle the modal `onFocus` it opens the modal again, creating an infinite loop
- blurring the input after we have sent out event to metamask mobile stops this infinite loop.

## How to test
- this is a fairly simple change to test with one caveat
- pull the repo/checkout branch
- run `yarn start` which should open the `http://localhost:3000/`
- it should open in your browser and work as expected
### Testing on mobile
- assuming you have done the above steps...
1. pull `main` and run the app on simulator with the `same network as localhost`. 
2. modify the `HOMEPAGE_URL` constant in `app/core/AppConstants.js` to have the value of `http://localhost:3000/`

<img width="1848" alt="Screen Shot 2022-04-19 at 1 22 56 PM" src="https://user-images.githubusercontent.com/22918444/164060425-a2e0c022-a33f-4565-8a82-a8953aa22168.png">

3. Modify the `HOMEPAGE_HOST` constant inside `app/components/Views/BrowserTab/index.js` to be `localhost:3000'`

<img width="1514" alt="Screen Shot 2022-04-19 at 1 24 18 PM" src="https://user-images.githubusercontent.com/22918444/164060638-c9c6a2a0-ca89-484a-98b4-dd997f834d9f.png">

4. these are needed since we block the autocomplete complete on sites that are [not the homepage](https://github.com/MetaMask/metamask-mobile/blob/main/app/core/RPCMethods/RPCMethodMiddleware.ts#L489-L491)
5. navigate to the browser and create a new tab
6. navigate to http://localhost:3000/ in the mobile browser (of the app)
7. click the search input
8. the full screen url modal should pop up without any pre populated data in the search bar
9. type some test searches and some some auto complete values should pop up
10. clicking autocomplete values takes you to the respective website or a duck duck go search result
11. closing the modal causes the input of the search bar to blur