### PR TITLE
Support `/dapps` subpath or root

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "eject": "react-scripts eject",
     "update-changelog": "./scripts/auto-changelog.sh"
   },
+  "homepage": ".",
   "eslintConfig": {
     "extends": "react-app"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -34,8 +34,11 @@ function App() {
 
   if (isLoading) return null
 
+  const currentPath = window.location.pathname;
+  const basename = currentPath.startsWith('/dapps') ? '/dapps' : undefined;
+
   return (
-      <Router>
+      <Router basename={basename}>
         <ScrollToTop>
           <div className="App">
             <Route exact path="/" component={Home} />


### PR DESCRIPTION
The page now supports being hosted at the root or at the `/dapps` subpath. Previously it only supported being hosted at the root.