### PR TITLE
Fix back button

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "eject": "react-scripts eject",
     "update-changelog": "./scripts/auto-changelog.sh"
   },
-  "homepage": ".",
+  "homepage": "https://metamask.github.io/dapps/",
   "eslintConfig": {
     "extends": "react-app"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -34,11 +34,8 @@ function App() {
 
   if (isLoading) return null
 
-  const currentPath = window.location.pathname;
-  const basename = currentPath.startsWith('/dapps') ? '/dapps' : undefined;
-
   return (
-      <Router basename={basename}>
+      <Router basename={'/dapps'}>
         <ScrollToTop>
           <div className="App">
             <Route exact path="/" component={Home} />


### PR DESCRIPTION
The back button was broken because the `homepage="."` configuration was incompatibile with how we were using the history API.

This means the page will now only work when hosted from the `/dapps/` path.